### PR TITLE
fix: Do not escape the footer info

### DIFF
--- a/resources/template/common/macro/common_macro.tmpl
+++ b/resources/template/common/macro/common_macro.tmpl
@@ -6,7 +6,7 @@
 {{- /* 页脚信息 */ -}}
 
 {{define "global.footer_info"}}
-    {{.options.blog_footer_info}}
+    {{noescape .options.blog_footer_info}}
 {{end }}
 
 {{- /* 页眉信息 */ -}}


### PR DESCRIPTION
在后台设置页脚信息后，发现博客页会把完整的信息显示出来，而不是显示HTML渲染后的内容：

![image](https://user-images.githubusercontent.com/50749070/209074328-9e5a375a-9a1c-437a-83dc-a19bdb811ac5.png)
![image](https://user-images.githubusercontent.com/50749070/209074294-1a094829-cb7d-4d12-9129-cc2bf637b10a.png)
![image](https://user-images.githubusercontent.com/50749070/209074282-5753c068-dec5-4d4b-a649-540a58433ced.png)

原因是页脚在渲染的时候被转义了，所以在 template 里面调一下noescape函数

效果：
![image](https://user-images.githubusercontent.com/50749070/209075522-d5825f3c-7912-44c0-bf99-639e1338f694.png)
