### PR TITLE
fix:spelling errors

### DIFF
--- a/handler/route.go
+++ b/handler/route.go
@@ -342,7 +342,7 @@ func (s *Server) RegisterRouters() {
 			contentAPIRouter.GET("/links", s.wrapHandler(s.ContentAPILinkHandler.ListLinks))
 			contentAPIRouter.GET("/links/team_view", s.wrapHandler(s.ContentAPILinkHandler.LinkTeamVO))
 
-			contentAPIRouter.GET("/options/comment", s.wrapHandler(s.ContentAPIOptionHander.Comment))
+			contentAPIRouter.GET("/options/comment", s.wrapHandler(s.ContentAPIOptionHandler.Comment))
 		}
 	}
 }

--- a/handler/server.go
+++ b/handler/server.go
@@ -75,7 +75,7 @@ type Server struct {
 	ContentAPILinkHandler     *api.LinkHandler
 	ContentAPIPostHandler     *api.PostHandler
 	ContentAPISheetHandler    *api.SheetHandler
-	ContentAPIOptionHander    *api.OptionHandler
+	ContentAPIOptionHandler   *api.OptionHandler
 }
 
 type ServerParams struct {
@@ -129,7 +129,7 @@ type ServerParams struct {
 	ContentAPILinkHandler     *api.LinkHandler
 	ContentAPIPostHandler     *api.PostHandler
 	ContentAPISheetHandler    *api.SheetHandler
-	ContentAPIOptionHander    *api.OptionHandler
+	ContentAPIOptionHandler   *api.OptionHandler
 }
 
 func NewServer(param ServerParams, lifecycle fx.Lifecycle) *Server {
@@ -192,7 +192,7 @@ func NewServer(param ServerParams, lifecycle fx.Lifecycle) *Server {
 		ContentAPILinkHandler:     param.ContentAPILinkHandler,
 		ContentAPIPostHandler:     param.ContentAPIPostHandler,
 		ContentAPISheetHandler:    param.ContentAPISheetHandler,
-		ContentAPIOptionHander:    param.ContentAPIOptionHander,
+		ContentAPIOptionHandler:   param.ContentAPIOptionHandler,
 		ContentSearchHandler:      param.ContentSearchHandler,
 	}
 	lifecycle.Append(fx.Hook{


### PR DESCRIPTION
There are some spelling errors on the `server.go` and `router.go`, and I tried to fix them.