### PR TITLE
fix tag bugs

### DIFF
--- a/handler/router.go
+++ b/handler/router.go
@@ -218,7 +218,7 @@ func (s *Server) RegisterRouters() {
 					tagRouter.GET("", s.wrapHandler(s.TagHandler.ListTags))
 					tagRouter.GET("/:id", s.wrapHandler(s.TagHandler.GetTagByID))
 					tagRouter.POST("", s.wrapHandler(s.TagHandler.CreateTag))
-					tagRouter.PUT("", s.wrapHandler(s.TagHandler.UpdateTag))
+					tagRouter.PUT("/:id", s.wrapHandler(s.TagHandler.UpdateTag))
 					tagRouter.DELETE("/:id", s.wrapHandler(s.TagHandler.DeleteTag))
 				}
 				{

--- a/service/impl/tag.go
+++ b/service/impl/tag.go
@@ -98,7 +98,7 @@ func (t tagServiceImpl) Delete(ctx context.Context, id int32) error {
 		}
 
 		postTagDAL := dal.GetQueryByCtx(txCtx).PostTag
-		_, err = tagDAL.WithContext(txCtx).Where(postTagDAL.TagID.Eq(id)).Delete()
+		_, err = postTagDAL.WithContext(txCtx).Where(postTagDAL.TagID.Eq(id)).Delete()
 		return err
 	})
 

--- a/service/theme/theme_fetcher.go
+++ b/service/theme/theme_fetcher.go
@@ -55,9 +55,10 @@ func (m *multipartZipThemeFetcherImpl) FetchTheme(ctx context.Context, file inte
 	}
 
 	diskFile, err := os.OpenFile(diskFilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o444)
-	if !errors.Is(err, os.ErrExist) {
+	if err != nil && !errors.Is(err, os.ErrExist) {
 		return nil, xerr.WithStatus(err, xerr.StatusInternalServerError).WithMsg("create file error")
 	}
+
 	defer diskFile.Close()
 
 	_, err = io.Copy(diskFile, srcThemeFile)


### PR DESCRIPTION
1. 文章 -> 标签 -> 所有标签 -> 清理未使用的标签  可复现
``` go
func (t tagServiceImpl) Delete(ctx context.Context, id int32) error {
	err := dal.Transaction(ctx, func(txCtx context.Context) error {
		tagDAL := dal.GetQueryByCtx(txCtx).Tag
		_, err := tagDAL.WithContext(txCtx).Where(tagDAL.ID.Value(id)).Delete()
		if err != nil {
			return WrapDBErr(err)
		}

		postTagDAL := dal.GetQueryByCtx(txCtx).PostTag
		_, err = postTagDAL.WithContext(txCtx).Where(postTagDAL.TagID.Eq(id)).Delete()  //  this line 
		return err
	})

	return err
}
```


3.  文章 -> 标签 -> 选择一个标签 -> 保存   找不到接口  