### PR TITLE
fix: Lower TLS version requirement for SMTP compatibility

### DIFF
--- a/service/impl/email.go
+++ b/service/impl/email.go
@@ -109,7 +109,7 @@ func (e *emailServiceImpl) getEmailProperties(ctx context.Context) (emailPropert
 
 func (e *emailServiceImpl) sendEmail(email *email.Email, properties emailProperties) error {
 	err := email.SendWithTLS(fmt.Sprintf("%s:%d", properties.Host, properties.SSLPort),
-		smtp.PlainAuth("", properties.Username, properties.Password, properties.Host), &tls.Config{ServerName: properties.Host, MinVersion: tls.VersionTLS13})
+		smtp.PlainAuth("", properties.Username, properties.Password, properties.Host), &tls.Config{ServerName: properties.Host, MinVersion: tls.VersionTLS12})
 	if err != nil {
 		return xerr.Email.Wrapf(err, "发送邮件错误 emailProperties=%v", properties).WithStatus(xerr.StatusInternalServerError).
 			WithMsg("发送邮件错误")


### PR DESCRIPTION
考虑到国内使用QQ的人数较多，用QQ邮箱的人数也会多，所以可能有相当部分的用户会使用SMTP来接收评论通知，但是测试发现，后台里填入QQ的SMTP服务无法正常测试使用，经发现是TLS版本兼容问题，降低一下版本要求即可。