### PR TITLE
fix: docker timezone

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -21,6 +21,11 @@ FROM alpine:latest as prod
 
 COPY --from=builder /app/ /app/
 
+RUN apk update \
+    && apk add --no-cache tzdata \
+    && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && echo "Asia/Shanghai" > /etc/timezone
+
 VOLUME /sonic
 EXPOSE 8080
 


### PR DESCRIPTION
fix https://github.com/go-sonic/sonic/issues/101

add tzdata in Dockerfile and set Asia/Shanghai as the default timezone

we can also change timezone by  specifying the environment variables `-e TZ=Asia/Shanghai`