### PR TITLE
fix: allow global update when clear action logs

### DIFF
--- a/service/impl/log.go
+++ b/service/impl/log.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"context"
+	"gorm.io/gorm"
 
 	"github.com/go-sonic/sonic/dal"
 	"github.com/go-sonic/sonic/model/dto"
@@ -18,7 +19,7 @@ func NewLogService() service.LogService {
 
 func (l *logServiceImpl) Clear(ctx context.Context) error {
 	logDAL := dal.GetQueryByCtx(ctx).Log
-	_, err := logDAL.WithContext(ctx).Delete()
+	_, err := logDAL.WithContext(ctx).Session(&gorm.Session{AllowGlobalUpdate: true}).Delete()
 	if err != nil {
 		return WrapDBErr(err)
 	}


### PR DESCRIPTION
now we can clear logs without error

![image](https://user-images.githubusercontent.com/107761771/222943667-fe1b5c30-3d25-4f27-a6fd-36ce80dbfad3.png)

reference: https://gorm.io/docs/delete.html#Block-Global-Delete