### PR TITLE
fix: upload file path

### DIFF
--- a/service/impl/attachment.go
+++ b/service/impl/attachment.go
@@ -158,7 +158,7 @@ func (a *attachmentServiceImpl) Upload(ctx context.Context, fileHeader *multipar
 		Path:      strings.ReplaceAll(attachmentDTO.Path, string(os.PathSeparator), "/"),
 		Size:      attachmentDTO.Size,
 		Suffix:    attachmentDTO.Suffix,
-		ThumbPath: attachmentDTO.ThumbPath,
+		ThumbPath: strings.ReplaceAll(attachmentDTO.Path, string(os.PathSeparator), "/"),
 		Type:      attachmentDTO.AttachmentType,
 		Width:     attachmentDTO.Width,
 	}
@@ -168,6 +168,14 @@ func (a *attachmentServiceImpl) Upload(ctx context.Context, fileHeader *multipar
 		return nil, WrapDBErr(err)
 	}
 	attachmentDTO.ID = attachmentEntity.ID
+	attachmentDTO.Path, err = fileStorage.GetFilePath(ctx, attachmentEntity.Path)
+	if err != nil {
+		return nil, err
+	}
+	attachmentDTO.ThumbPath, err = fileStorage.GetFilePath(ctx, attachmentEntity.ThumbPath)
+	if err != nil {
+		return nil, err
+	}
 
 	return attachmentDTO, nil
 }


### PR DESCRIPTION
### Relative issue
part of #197 

### Changes
- the path separator for `ThumbPath` has been updated to use the URL separator
- `Path` and `ThumbPath` are now handled like `ConvertToDTO` to get the correct result

### ScreenShot
![image](https://user-images.githubusercontent.com/107761771/226082136-d8f5d2f2-43db-4a5b-b441-6a857a8ea640.png)
