### PR TITLE
feat: assign a version number at compile time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Show workflow information
         run: |
           echo "GOOS: $GOOS, GOARCH: $GOARCH"
+          echo "BUILD_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Build
         uses: crazy-max/ghaction-xgo@v2
@@ -66,7 +67,7 @@ jobs:
           v: true
           x: false
           race: false
-          ldflags: -s -w
+          ldflags: -s -w -X 'github.com/go-sonic/sonic/consts.SonicVersion=${{github.ref_name}}' -X 'github.com/go-sonic/sonic/consts.BuildCommit=${{github.sha}}' -X 'github.com/go-sonic/sonic/consts.BuildTime=${{env.BUILD_TIME}}'
           buildmode: default
           trimpath: true
 

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -19,7 +19,6 @@ const (
 )
 
 const (
-	SonicVersion              = "1.0.0"
 	SonicBackupPrefix         = "sonic-backup-"
 	SonicDataExportPrefix     = "sonic-data-export-"
 	SonicBackupMarkdownPrefix = "sonic-backup-markdown-"
@@ -40,7 +39,10 @@ const (
 	ThemeCustomPostPrefix  = "post_"
 )
 
-// StartTime 系统启动时间
-var StartTime time.Time
-
-var DatabaseVersion string
+var (
+	StartTime       time.Time = time.Now()
+	DatabaseVersion string
+	SonicVersion    = "v1.0.0"
+	BuildTime       string
+	BuildCommit     string
+)

--- a/event/listener/start.go
+++ b/event/listener/start.go
@@ -3,7 +3,6 @@ package listener
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -37,7 +36,6 @@ func (s *StartListener) HandleEvent(ctx context.Context, startEvent event.Event)
 	if _, ok := startEvent.(*event.StartEvent); !ok {
 		return nil
 	}
-	consts.StartTime = time.Now()
 
 	err := s.createOptions()
 	if err != nil {

--- a/service/impl/admin.go
+++ b/service/impl/admin.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	uuid2 "github.com/google/uuid"
@@ -184,7 +183,7 @@ func (a *adminServiceImpl) RefreshToken(ctx context.Context, refreshToken string
 func (a *adminServiceImpl) GetEnvironments(ctx context.Context) *dto.EnvironmentDTO {
 	environments := &dto.EnvironmentDTO{
 		Database:  string(dal.DBType) + " " + consts.DatabaseVersion,
-		Version:   runtime.Version(),
+		Version:   consts.SonicVersion,
 		StartTime: consts.StartTime.UnixMilli(),
 		Mode:      util.IfElse(a.Config.Sonic.Mode == "", "production", a.Config.Sonic.Mode).(string),
 	}


### PR DESCRIPTION
Use compile time assignment capabilities to set the version number to avoid changing the code every time a new version is released 

#187 