### PR TITLE
fix: sonic url in template and default post

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,10 +1,6 @@
 name: Linter
 
 on:
-  push:
-    paths:
-      - "**/*.go"
-      - ".github/workflows/linter.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,38 @@
+name: Release-Docker
+
+on:
+  release:
+    types: [published]     
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - 
+        name: Set build time
+        run: |
+          echo "BUILD_TIME=$(date +%FT%T%z)" >> $GITHUB_ENV          
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/arm64,linux/amd64
+          push: true
+          file: ./scripts/Dockerfile
+          tags: gosonic/sonic:test
+          build-args: |
+            SONIC_VERSION=${{github.ref_name}}
+            BUILD_COMMIT=${{github.sha}}
+            BUILD_TIME=${{env.BUILD_TIME}}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -31,7 +31,7 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           file: ./scripts/Dockerfile
-          tags: gosonic/sonic:test
+          tags: gosonic/sonic:latest,gosonic/sonic:${{github.ref_name}}
           build-args: |
             SONIC_VERSION=${{github.ref_name}}
             BUILD_COMMIT=${{github.sha}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Show workflow information
         run: |
           echo "GOOS: $GOOS, GOARCH: $GOARCH"
-          echo "BUILD_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
+          echo "BUILD_TIME=$(date +%FT%T%z)" >> $GITHUB_ENV
 
       - name: Build
         uses: crazy-max/ghaction-xgo@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /upload
 /.vscode
 sonic.db
+sonic
 __debug_bin
 /resources/template/theme/
 !/resources/template/theme/default-theme-anatole

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -19,12 +19,7 @@ sqlite3:
 
 
 mysql:
-  host: 127.0.0.1
-  port: 3306
-  db: sonicdb
-  username: "root"
-  password: "12345678"
-
+  dsn: username:password@tcp(host:port)/db_name?charset=utf8mb4&parseTime=True&loc=Local&interpolateParams=true
 
 sonic:
   mode: "production"

--- a/config/model.go
+++ b/config/model.go
@@ -16,13 +16,11 @@ type PostgreSQL struct {
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 }
+
 type MySQL struct {
-	Host     string `mapstructure:"host"`
-	Port     string `mapstructure:"port"`
-	DB       string `mapstructure:"db"`
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
+	Dsn string `mapstructure:"dsn"`
 }
+
 type SQLite3 struct {
 	Enable bool `mapstructure:"enable"`
 	File   string

--- a/dal/dal.go
+++ b/dal/dal.go
@@ -2,7 +2,6 @@ package dal
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -17,9 +16,6 @@ import (
 	"github.com/go-sonic/sonic/model/entity"
 	"github.com/go-sonic/sonic/util/xerr"
 )
-
-// mysqlDsn example  user:password@tcp(127.0.0.1:3306)/dbname?charset=utf8mb4&parseTime=True&loc=Local
-const mysqlDsn = "%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local&timeout=3s&readTimeout=1s&writeTimeout=1s&interpolateParams=true"
 
 var (
 	DB     *gorm.DB
@@ -66,8 +62,9 @@ func initMySQL(conf *config.Config, gormLogger logger.Interface) (*gorm.DB, erro
 	if mysqlConfig == nil {
 		return nil, xerr.WithMsg(nil, "nil MySQL config")
 	}
-	dsn := fmt.Sprintf(mysqlDsn, mysqlConfig.Username, mysqlConfig.Password, mysqlConfig.Host, mysqlConfig.Port, mysqlConfig.DB)
-	sonicLog.Info("try connect to MySQL", zap.String("dsn", fmt.Sprintf(mysqlDsn, mysqlConfig.Username, "***", mysqlConfig.Host, mysqlConfig.Port, mysqlConfig.DB)))
+	dsn := mysqlConfig.Dsn
+
+	sonicLog.Info("try connect to MySQL", zap.String("dsn", `Use dsn in config`))
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
 		Logger:                   gormLogger,
 		PrepareStmt:              true,

--- a/resources/template/common/web/atom.tmpl
+++ b/resources/template/common/web/atom.tmpl
@@ -31,7 +31,7 @@
             <link rel="self" type="application/atom+xml" href="{{.atom_url}}"/>
         {{end}}
         <rights>Copyright © {{.now.Format "2006"}}, {{.blog_title}}</rights>
-        <generator uri="https://go-sonic.org/" version="{{.version}}">Sonic</generator>
+        <generator uri="https://github.com/go-sonic/sonic" version="{{.version}}">Sonic</generator>
         {{if .posts }}
             {{range $post :=.posts}}
                 <entry>

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,14 +1,16 @@
 FROM golang:1.19.3-alpine as builder
-
 RUN apk --no-cache add git ca-certificates gcc g++
 
-WORKDIR /go/src/github.com/go-sonic/
-
-RUN git clone --recursive --depth 1 https://github.com/go-sonic/sonic.git
-
+COPY . /go/src/github.com/go-sonic/sonic/
 WORKDIR /go/src/github.com/go-sonic/sonic
 
-RUN GOPROXY=https://goproxy.cn CGO_ENABLED=1 GOOS=linux go build -o sonic -ldflags="-s -w" -trimpath .
+ARG BUILD_COMMIT
+ARG BUILD_TIME
+ARG SONIC_VERSION
+
+    
+RUN CGO_ENABLED=1 GOOS=linux && \
+go build -o sonic -ldflags="-s -w -X github.com/go-sonic/sonic/consts.SonicVersion=${SONIC_VERSION} -X github.com/go-sonic/sonic/consts.BuildCommit=${BUILD_COMMIT} -X github.com/go-sonic/sonic/consts.BuildTime=${BUILD_TIME}" -trimpath .
 
 RUN mkdir -p /app/conf && \
     mkdir /app/resources && \
@@ -17,12 +19,14 @@ RUN mkdir -p /app/conf && \
     cp -r /go/src/github.com/go-sonic/sonic/resources /app/ && \
     cp /go/src/github.com/go-sonic/sonic/scripts/docker_init.sh /app/
 
+
+
+
 FROM alpine:latest as prod
 
 COPY --from=builder /app/ /app/
 
-RUN apk update \
-    && apk add --no-cache tzdata \
+RUN  apk add --no-cache tzdata \
     && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 

--- a/service/impl/install.go
+++ b/service/impl/install.go
@@ -184,7 +184,7 @@ func (i installServiceImpl) createDefaultPost(ctx context.Context, category *ent
 > 这是一篇自动生成的文章，请删除这篇文章之后开始你的创作吧！
 `
 	formatContent := `<h2 id="hello-sonic" tabindex="-1">Hello Sonic</h2>
-	<p>如果你看到了这一篇文章，那么证明你已经安装成功了，感谢使用 <a href="https://go-sonic.org" target="_blank">Sonic</a> 进行创作，希望能够使用愉快。</p>
+	<p>如果你看到了这一篇文章，那么证明你已经安装成功了，感谢使用 <a href="https://github.com/go-sonic/sonic" target="_blank">Sonic</a> 进行创作，希望能够使用愉快。</p>
 	<h2 id="%E7%9B%B8%E5%85%B3%E9%93%BE%E6%8E%A5" tabindex="-1">相关链接</h2>
 	<ul>
 	<li>官网：<a href="https://github.com/go-sonic" target="_blank">https://github.com/go-sonic</a></li>


### PR DESCRIPTION
the link in template and default post `https://go-sonic.org` is inaccessible. It might even take users to some unexpected pages. This PR replaces it with `https://github.com/go-sonic/sonic`.