### PR TITLE
fix: comment author url validation

### DIFF
--- a/handler/content/api/journal.go
+++ b/handler/content/api/journal.go
@@ -204,7 +204,13 @@ func (j *JournalHandler) CreateComment(ctx *gin.Context) (interface{}, error) {
 	p := param.Comment{}
 	err := ctx.ShouldBindJSON(&p)
 	if err != nil {
-		return nil, err
+		return nil, xerr.WithStatus(err, xerr.StatusBadRequest).WithMsg("Parameter error")
+	}
+	if p.AuthorURL != "" {
+		err = util.Validate.Var(p.AuthorURL, "http_url")
+		if err != nil {
+			return nil, xerr.WithStatus(err, xerr.StatusBadRequest).WithMsg("Parameter error")
+		}
 	}
 	p.Author = template.HTMLEscapeString(p.Author)
 	p.AuthorURL = template.HTMLEscapeString(p.AuthorURL)

--- a/handler/content/api/post.go
+++ b/handler/content/api/post.go
@@ -163,7 +163,13 @@ func (p *PostHandler) CreateComment(ctx *gin.Context) (interface{}, error) {
 	comment := param.Comment{}
 	err := ctx.ShouldBindJSON(&comment)
 	if err != nil {
-		return nil, err
+		return nil, xerr.WithStatus(err, xerr.StatusBadRequest).WithMsg("Parameter error")
+	}
+	if comment.AuthorURL != "" {
+		err = util.Validate.Var(comment.AuthorURL, "http_url")
+		if err != nil {
+			return nil, xerr.WithStatus(err, xerr.StatusBadRequest).WithMsg("Parameter error")
+		}
 	}
 	comment.Author = template.HTMLEscapeString(comment.Author)
 	comment.AuthorURL = template.HTMLEscapeString(comment.AuthorURL)

--- a/handler/content/api/sheet.go
+++ b/handler/content/api/sheet.go
@@ -163,7 +163,13 @@ func (s *SheetHandler) CreateComment(ctx *gin.Context) (interface{}, error) {
 	comment := param.Comment{}
 	err := ctx.ShouldBindJSON(&comment)
 	if err != nil {
-		return nil, err
+		return nil, xerr.WithStatus(err, xerr.StatusBadRequest).WithMsg("Parameter error")
+	}
+	if comment.AuthorURL != "" {
+		err = util.Validate.Var(comment.AuthorURL, "http_url")
+		if err != nil {
+			return nil, xerr.WithStatus(err, xerr.StatusBadRequest).WithMsg("Parameter error")
+		}
 	}
 	comment.Author = template.HTMLEscapeString(comment.Author)
 	comment.AuthorURL = template.HTMLEscapeString(comment.AuthorURL)


### PR DESCRIPTION
This PR fix the validation of the author URL in comments and the error messages. Previously, the validation did not check if the URL was a valid HTTP URL, which could have caused issues such as typos and XSS attacks.